### PR TITLE
Multiply Strings

### DIFF
--- a/multiplyStrings.js
+++ b/multiplyStrings.js
@@ -20,6 +20,5 @@ function multiplyStrings(num1, num2) {
     return result.join('');
 }
 
-// Test cases
-console.log(multiplyStrings("2", "3")); // Output: "6"
-console.log(multiplyStrings("123", "456")); // Output: "56088"
+console.log(multiplyStrings("2", "3")); 
+console.log(multiplyStrings("123", "456")); 

--- a/multiplyStrings.js
+++ b/multiplyStrings.js
@@ -1,0 +1,25 @@
+function multiplyStrings(num1, num2) {
+    const m = num1.length;
+    const n = num2.length;
+    const result = Array(m + n).fill(0);
+
+    for (let i = m - 1; i >= 0; i--) {
+        for (let j = n - 1; j >= 0; j--) {
+            const mul = (num1[i] - '0') * (num2[j] - '0');
+            const sum = mul + result[i + j + 1];
+
+            result[i + j] += Math.floor(sum / 10);
+            result[i + j + 1] = sum % 10;
+        }
+    }
+
+    while (result[0] === 0 && result.length > 1) {
+        result.shift();
+    }
+
+    return result.join('');
+}
+
+// Test cases
+console.log(multiplyStrings("2", "3")); // Output: "6"
+console.log(multiplyStrings("123", "456")); // Output: "56088"


### PR DESCRIPTION
Given two non-negative integers num1 and num2 represented as strings, return the product of num1 and num2, also represented as a string.

Note: You must not use any built-in BigInteger library or convert the inputs to integer directly.

Example 1:

Input: num1 = "2", num2 = "3"
Output: "6"

Example 2:
Input: num1 = "123", num2 = "456"
Output: "56088"
 

Constraints:
1 <= num1.length, num2.length <= 200
num1 and num2 consist of digits only.
Both num1 and num2 do not contain any leading zero, except the number 0 itself.
